### PR TITLE
don't inherit Address from Tokenable

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,4 +1,10 @@
-class Address < Tokenable
+class Address
+
+  include Mongoid::Document
+  include Mongoid::Timestamps
+  include Mongoid::Token
+  
+  token :contains => :alphanumeric, :length => 6
 
   before_validation :generate_full_address
   validates_uniqueness_of :full_address


### PR DESCRIPTION
This took me a while to work out, but the performance increase is stunning.

All the models were inheriting from Tokenable, presumably to keep the token generation and other code DRY. However, because mongoid automatically uses inheritance to put things in the same collection, this means that Addresses were in the same collection as _everything else_. That's 3.5 million rows of streets, postcodes, etc, and in the case of my test DB 92 addresses. Finding all addresses was a matter of doing a complex query on `_type` to see if it matched `Address`, rather than just listing an entire collection.

This change makes Address into its own collection, and suddenly the entire app is lightning fast.

A possible reason for sharing tables might have been to enforce uniqueness of tokens, but as they are different types, I don't think it's a problem if a token clashes between an address and, say, a street. What do you think?
